### PR TITLE
Allow Crushinator options in hyphenated form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### (Upcoming)
 
+* [#5](https://github.com/tedconf/js-crushinator-helpers/issues/5) Allow hyphenated form for Crushinator options
+
 [(Commit list.)](https://github.com/tedconf/js-crushinator-helpers/compare/129f407...master)
 
 ### 2.1.0

--- a/README.md
+++ b/README.md
@@ -158,6 +158,19 @@ crushinator.crush('http://images.ted.com/image.jpg', {
 
 The above example would resize the original image to 640x480 and then take a 200x100 crop of the resized image, starting at 50x25.
 
+Crop configuration options can also be sent in hyphenated form:
+
+```javascript
+crushinator.crush('http://images.ted.com/image.jpg', {
+    width: 640,
+    height: 480,
+    'crop-width': 200, 'crop-height': 100,
+    'crop-x': 50, 'crop-y': 25,
+    'crop-afterResize': true
+  })
+  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?quality=93'
+```
+
 ### uncrush
 
 Restore a previously crushed URL to its original form.

--- a/src/lib/param-builder.js
+++ b/src/lib/param-builder.js
@@ -12,10 +12,36 @@ export class ParamBuilder {
   }
 
   /**
+  Convert values from hyphenated form to an object tree.
+  */
+  dehyphenate(values) {
+    const dehyphenated = {};
+
+    for (const key in values) {
+      if (values.hasOwnProperty(key)) {
+        const value = values[key];
+        const splitted = key.match(/([^-]+)-+(.*)/);
+
+        if (splitted && this.options.hasOwnProperty(splitted[1])) {
+          dehyphenated[splitted[1]] = dehyphenated[splitted[1]] || {};
+          dehyphenated[splitted[1]][splitted[2]] = value;
+        } else {
+          dehyphenated[key] = value;
+        }
+      }
+    }
+
+    return dehyphenated;
+  }
+
+  /**
   Returns parameters in object form.
   */
   get(values) {
     const params = {};
+
+    // Convert "crop-width" to crop.width etc.
+    values = this.dehyphenate(values);
 
     for (const key in this.options) {
       if (values.hasOwnProperty(key)) {

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -196,6 +196,17 @@ describe('crushinator', function () {
           crushed + '?c=320%2C240%2C250%2C150'
         );
       });
+
+      it('should recognize crop options in hyphenated form', function () {
+        assert.equal(
+          crushinator.crush(uncrushed, {
+            'crop-width': 320, 'crop-height': 240,
+            'crop-x': 250, 'crop-y': 150,
+            'crop-afterResize': true,
+          }),
+          crushed + '?c=320%2C240%2C250%2C150'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Some Crushinator options are themselves objects with subconfigurations:

```javascript
crushinator.crush('http://images.ted.com/image.jpg', {
    crop: {
      width: 200, height: 100,
      x: 50, y: 25,
      afterResize: true
    }
  })
  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?quality=93'
```

Let's accept them in hyphenated form:

```javascript
crushinator.crush('http://images.ted.com/image.jpg', {
    'crop-width': 200, 'crop-height': 100,
    'crop-x': 50, 'crop-y': 25,
    'crop-afterResize': true
  })
  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?quality=93'
```

This would be useful for Handlebars helpers. For example, a helper could be registered like so:

```javascript
Handlebars.registerHelper('crush', function (url, options) {
  return crushinator.crush(url, options.hash);
});
```

And then in Handlebars, Crushinator image optimizations including crop could be configured via hyphenated hash options:

```handlebars
<img src="{{crush image width=320 crop-width=640 crop-height=480}}" alt="Probably a cat">
```

This only applies to `crop` currently, but other similarly objecty options are on their way.