### PR TITLE
Deprecate Crushinator options as sending query strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#5](https://github.com/tedconf/js-crushinator-helpers/issues/5) Allow hyphenated form for Crushinator options
 * [#6](https://github.com/tedconf/js-crushinator-helpers/issues/6) Provide AMD-only distribution
+* [#7](https://github.com/tedconf/js-crushinator-helpers/issues/7) Deprecate direct use of string API for query params
 
 [(Commit list.)](https://github.com/tedconf/js-crushinator-helpers/compare/129f407...master)
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "mocha": "^2.4.5",
     "rollup": "^0.25.4",
     "rollup-plugin-babel": "^2.4.0",
-    "rollup-plugin-uglify": "^0.2.0"
+    "rollup-plugin-uglify": "^0.2.0",
+    "sinon": "^1.17.3"
   }
 }

--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -9,6 +9,7 @@ http://github.com/tedconf/js-crushinator-helpers
 import * as cropOption from './lib/crop-option';
 import {ParamBuilder} from './lib/param-builder';
 import {prepNumber} from './lib/preppers';
+import {warn} from './lib/log';
 
 /**
 A list of strings and regular expressions
@@ -118,6 +119,12 @@ export function crush(url, options={}) {
   // Apply host whitelist
   if (!crushable(url)) {
     return url;
+  }
+
+  // Complain about use of the deprecated string API
+  if (typeof options === 'string') {
+    warn('Sending Crushinator options as a query string is ' +
+        'deprecated. Please use the object format.');
   }
 
   // Stringify object options

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -1,4 +1,6 @@
 import assert from 'assert';
+import * as sinon from 'sinon';
+
 import * as crushinator from '../src/crushinator';
 
 // Hosts where crushable images are stored
@@ -75,6 +77,25 @@ describe('crushinator', function () {
   });
 
   describe('crush', function () {
+    const sandbox = sinon.sandbox.create();
+
+    beforeEach(function () {
+      sandbox.spy(console, 'warn');
+    });
+
+    afterEach(function () {
+      sandbox.restore();
+    });
+
+    it('should warn about use of the deprecated query string format', function () {
+      crushinator.crush('http://images.ted.com/image.jpg', 'w=320');
+
+      sinon.assert.calledOnce(console.warn);
+      sinon.assert.calledWith(console.warn,
+        'Sending Crushinator options as a query string is ' +
+        'deprecated. Please use the object format.');
+    });
+
     imageHosts.forEach(function (imageHost) {
       it('should provide secure Crushinator URLs for images hosted on ' + imageHost, function () {
         let url = '//' + imageHost + '/image.jpg';

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -93,7 +93,10 @@ describe('crushinator', function () {
     });
 
     it('should warn about deprecation of the deprecated query string format', function () {
-      crushinator.crush(uncrushed, 'w=320');
+      assert.equal(
+        crushinator.crush(uncrushed, 'w=320'),
+        crushed + '?w=320'
+      );
 
       sinon.assert.calledOnce(console.warn);
       sinon.assert.calledWith(console.warn,


### PR DESCRIPTION
**Note / update:** #9 is a prerequisite to this.

---

Per #3 sending a query string to the `crush` method is a potential XSS vulnerability and should be deprecated.

Warn about this deprecation via console if a string is passed in.