### PR TITLE
Treat unrecognized optimization options as query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#5](https://github.com/tedconf/js-crushinator-helpers/issues/5) Allow hyphenated form for Crushinator options
 * [#6](https://github.com/tedconf/js-crushinator-helpers/issues/6) Provide AMD-only distribution
+* [#8](https://github.com/tedconf/js-crushinator-helpers/issues/8) Accept custom query parameters in the options object
 
 [(Commit list.)](https://github.com/tedconf/js-crushinator-helpers/compare/129f407...master)
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This is helpful for dealing with dynamic image URLs.
 
 #### crush options
 
-Some more detail and examples for individual Crushinator helper options:
+This section lists the image optimization options for which the JS helpers provide an API. Anything included in the options object that _isn't_ one of the options listed here will be appended to the Crushinator URL as a query parameter.
 
 ##### width
 

--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -9,6 +9,7 @@ http://github.com/tedconf/js-crushinator-helpers
 import * as cropOption from './lib/crop-option';
 import {ParamBuilder} from './lib/param-builder';
 import {prepNumber} from './lib/preppers';
+import {serialize} from './lib/query-string';
 
 /**
 A list of strings and regular expressions
@@ -121,8 +122,11 @@ export function crush(url, options={}) {
   }
 
   // Stringify object options
-  if (typeof options === 'object') { // or: everything is a duck
-    options = params.serialize(options);
+  if (typeof options === 'object') {
+    options = serialize(Object.assign(
+      params.omitOptions(options),  // = custom parameters
+      params.parameterize(options)  // = standard options
+    ));
   }
 
   return 'https://tedcdnpi-a.akamaihd.net/r/' +

--- a/src/lib/param-builder.js
+++ b/src/lib/param-builder.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import {serialize} from './query-string';
-
 export class ParamBuilder {
 
   /**
@@ -37,7 +35,7 @@ export class ParamBuilder {
   /**
   Returns parameters in object form.
   */
-  get(values) {
+  parameterize(values) {
     const params = {};
 
     // Convert "crop-width" to crop.width etc.
@@ -60,10 +58,26 @@ export class ParamBuilder {
   }
 
   /**
-  Returns parameters in query string form.
+  Returns true if `optionName` looks like a valid option.
   */
-  serialize(values) {
-    return serialize(this.get(values));
+  hasOption(optionName) {
+    return this.options.hasOwnProperty(optionName.split('-').shift());
+  }
+
+  /**
+  Pass in an object and it returns a new one with the properties
+  that look like this ParamBuilder's options removed.
+  */
+  omitOptions(values) {
+    const pulled = {};
+
+    for (let key in values) {
+      if (!this.hasOption(key)) {
+        pulled[key] = values[key];
+      }
+    }
+
+    return pulled;
   }
 
 }

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -207,6 +207,13 @@ describe('crushinator', function () {
           crushed + '?c=320%2C240%2C250%2C150'
         );
       });
+
+      it('should append unrecognized properties as query parameters', function () {
+        assert.equal(
+          crushinator.crush(uncrushed, { w: 640, u: { r: 3, s: 1 } }),
+          crushed + '?w=640&u%5Br%5D=3&u%5Bs%5D=1'
+        );
+      });
     });
   });
 });


### PR DESCRIPTION
Per conversation in #7, this is mostly to provide support for experimental Crushinator configurations once we deprecate direct use of query strings.

With this change, the options POJO can potentially contain helper-specific API options alongside plain old query parameters:

```javascript
crushinator.crush('http://images.ted.com/image.jpg', {
    width: 320,   // JS helper API
    height: 240,  // JS helper API
    c: '200,100'  // Plain old query param
  })
  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320&h=240&c=200,100'
```