### PR TITLE
Add option for unvetted Crushinator query parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#5](https://github.com/tedconf/js-crushinator-helpers/issues/5) Allow hyphenated form for Crushinator options
 * [#6](https://github.com/tedconf/js-crushinator-helpers/issues/6) Provide AMD-only distribution
+* [#9](https://github.com/tedconf/js-crushinator-helpers/issues/9) Add option for custom query parameters
 
 [(Commit list.)](https://github.com/tedconf/js-crushinator-helpers/compare/129f407...master)
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,8 @@ crushinator.crush('http://images.ted.com/image.jpg', {
   // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=200&c=100%2C100'
 ```
 
+This allows you to directly apply [any of Crushinator's query parameters](https://github.com/tedconf/crushinator#usage) instead of using this helper's wrapper API.
+
 ### uncrush
 
 Restore a previously crushed URL to its original form.

--- a/README.md
+++ b/README.md
@@ -171,6 +171,18 @@ crushinator.crush('http://images.ted.com/image.jpg', {
   // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?quality=93'
 ```
 
+##### query
+
+The `query` option can be used to append custom query parameters to the Crushinator URL:
+
+```javascript
+crushinator.crush('http://images.ted.com/image.jpg', {
+    width: 200,
+    query: { c: '100,100' }
+  })
+  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=200&c=100%2C100'
+```
+
 ### uncrush
 
 Restore a previously crushed URL to its original form.

--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -9,6 +9,7 @@ http://github.com/tedconf/js-crushinator-helpers
 import * as cropOption from './lib/crop-option';
 import {ParamBuilder} from './lib/param-builder';
 import {prepNumber} from './lib/preppers';
+import {serialize} from './lib/query-string';
 
 /**
 A list of strings and regular expressions
@@ -122,7 +123,10 @@ export function crush(url, options={}) {
 
   // Stringify object options
   if (typeof options === 'object') { // or: everything is a duck
-    options = params.serialize(options);
+    options = serialize(Object.assign(
+      params.get(options),
+      options.params || {}
+    ));
   }
 
   return 'https://tedcdnpi-a.akamaihd.net/r/' +

--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -125,7 +125,7 @@ export function crush(url, options={}) {
   if (typeof options === 'object') { // or: everything is a duck
     options = serialize(Object.assign(
       params.get(options),
-      options.params || {}
+      options.query || {}
     ));
   }
 

--- a/src/lib/param-builder.js
+++ b/src/lib/param-builder.js
@@ -1,7 +1,5 @@
 'use strict';
 
-import {serialize} from './query-string';
-
 export class ParamBuilder {
 
   /**
@@ -57,13 +55,6 @@ export class ParamBuilder {
     }
 
     return params;
-  }
-
-  /**
-  Returns parameters in query string form.
-  */
-  serialize(values) {
-    return serialize(this.get(values));
   }
 
 }

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -197,10 +197,10 @@ describe('crushinator', function () {
         );
       });
 
-      it('should recognize the custom params option', function () {
+      it('should recognize the custom query option', function () {
         assert.equal(
           crushinator.crush(uncrushed, {
-            params: {
+            query: {
               foo: 1,
               bar: 'baz',
             },

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -197,6 +197,18 @@ describe('crushinator', function () {
         );
       });
 
+      it('should recognize the custom params option', function () {
+        assert.equal(
+          crushinator.crush(uncrushed, {
+            params: {
+              foo: 1,
+              bar: 'baz',
+            },
+          }),
+          crushed + '?foo=1&bar=baz'
+        );
+      });
+
       it('should recognize crop options in hyphenated form', function () {
         assert.equal(
           crushinator.crush(uncrushed, {


### PR DESCRIPTION
Per conversation in #7 and #8, this is mostly to provide support for experimental Crushinator configurations once we deprecate direct use of query strings.

With this change, the options POJO can potentially contain plain old query parameters in a `params` namespace:

```javascript
crushinator.crush('http://images.ted.com/image.jpg', {
    width: 320, height: 240,
    params: { c: '200,100' }
  })
  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320&h=240&c=200,100'
```