### PR TITLE
Crushinator is now hosted on pi.tedcdn.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### (Upcoming)
 
+* [#11](https://github.com/tedconf/js-crushinator-helpers/issues/11) Accommodate Crushinator's move to `pi.tedcdn.com`
+
 [(Commit list.)](https://github.com/tedconf/js-crushinator-helpers/compare/e19749f...master)
 
 ### 2.2.0

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ JavaScript methods to produce [Crushinator](https://github.com/tedconf/crushinat
 
 ```javascript
 crushinator.crush('http://images.ted.com/image.jpg', { width: 320 })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=320'
 ```
 
 ## Installation
@@ -62,7 +62,7 @@ Example use:
 
 ```javascript
 crushinator.crush('http://images.ted.com/image.jpg', { width:  320 })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=320'
 ```
 
 Crushinator only operates on images hosted on whiteslisted domains. If you use the `crush` method on an image outside of that whitelist, it will simply return the original URL:
@@ -94,7 +94,7 @@ Example:
 
 ```javascript
 crushinator.crush('http://images.ted.com/image.jpg', { width: 320 })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=320'
 ```
 
 ##### height
@@ -113,7 +113,7 @@ Example:
 
 ```javascript
 crushinator.crush('http://images.ted.com/image.jpg', { height: 240 })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?h=240'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?h=240'
 ```
 
 ##### quality
@@ -126,7 +126,7 @@ Example:
 
 ```javascript
 crushinator.crush('http://images.ted.com/image.jpg', { quality: 93 })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?quality=93'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?quality=93'
 ```
 
 ##### crop
@@ -153,7 +153,7 @@ crushinator.crush('http://images.ted.com/image.jpg', {
       afterResize: true
     }
   })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=640&h=480&c=200%2C100%2C50%2C25'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=640&h=480&c=200%2C100%2C50%2C25'
 ```
 
 The above example would resize the original image to 640x480 and then take a 200x100 crop of the resized image, starting at 50x25.
@@ -168,7 +168,7 @@ crushinator.crush('http://images.ted.com/image.jpg', {
     'crop-x': 50, 'crop-y': 25,
     'crop-afterResize': true
   })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=640&h=480&c=200%2C100%2C50%2C25'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=640&h=480&c=200%2C100%2C50%2C25'
 ```
 
 ##### query
@@ -180,7 +180,7 @@ crushinator.crush('http://images.ted.com/image.jpg', {
     width: 200,
     query: { c: '100,100' }
   })
-  // => 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=200&c=100%2C100'
+  // => 'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=200&c=100%2C100'
 ```
 
 This allows you to directly apply [any of Crushinator's query parameters](https://github.com/tedconf/crushinator#usage) instead of using this helper's wrapper API.
@@ -202,7 +202,7 @@ crushinator.uncrush ( url )
 Example:
 
 ```javascript
-crushinator.uncrush('https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320')
+crushinator.uncrush('https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=320')
   // => 'https://images.ted.com/image.jpg'
 ```
 

--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -76,7 +76,7 @@ Restore a previously crushed URL to its original form.
 */
 export function uncrush(url) {
   const parts = url.match(
-    /(.+)?\/\/(?:img(?:-ssl)?\.tedcdn\.com|tedcdnpi-a\.akamaihd\.net)\/r\/([^?]+)/
+    /(.+)?\/\/(?:(?:img(?:-ssl)?|pi)\.tedcdn\.com|tedcdnpi-a\.akamaihd\.net)\/r\/([^?]+)/
   );
 
   // Avoid double-crushing images
@@ -92,7 +92,7 @@ Returns a version of the image URL that uses Crushinator with the
 specified options string:
 
     crush('http://images.ted.com/image.jpg', 'w=320')
-      => 'https://tedcdnpi-a.akamaihd.net/images.ted.com/image.jpg?w=320'
+      => 'https://pi.tedcdn.com/images.ted.com/image.jpg?w=320'
 
 @public
 @param {string} url - URL of image to be optimized.
@@ -137,7 +137,7 @@ export function crush(url, options={}) {
     ));
   }
 
-  return 'https://tedcdnpi-a.akamaihd.net/r/' +
+  return 'https://pi.tedcdn.com/r/' +
     url.replace(/.*\/\//, '') +
     (options ? '?' + options : '');
 }

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -31,6 +31,7 @@ const crushinatorHosts = [
   'img.tedcdn.com',
   'img-ssl.tedcdn.com',
   'tedcdnpi-a.akamaihd.net',
+  'pi.tedcdn.com',
 ];
 
 describe('crushinator', function () {
@@ -50,7 +51,7 @@ describe('crushinator', function () {
 
   describe('uncrush', function () {
     crushinatorHosts.forEach(function (crushinatorHost) {
-      it('should revert images that were hosted on ' + crushinatorHost, function () {
+      it('should revert images that were crushed by ' + crushinatorHost, function () {
         imageHosts.forEach(function (imageHost) {
           let url =
             '//' + crushinatorHost + '/r/' +
@@ -84,7 +85,7 @@ describe('crushinator', function () {
 
     beforeEach(function () {
       uncrushed = 'https://images.ted.com/image.jpg';
-      crushed = 'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg';
+      crushed = 'https://pi.tedcdn.com/r/images.ted.com/image.jpg';
 
       sandbox.spy(console, 'warn');
     });
@@ -124,7 +125,7 @@ describe('crushinator', function () {
       let url = 'https://img-ssl.tedcdn.com/r/images.ted.com/image.jpg';
       assert.equal(
         crushinator.crush(url, { width: 320 }),
-        'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg?w=320'
+        'https://pi.tedcdn.com/r/images.ted.com/image.jpg?w=320'
       );
     });
 
@@ -133,12 +134,12 @@ describe('crushinator', function () {
 
       assert.equal(
         crushinator.crush(url),
-        'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg'
+        'https://pi.tedcdn.com/r/images.ted.com/image.jpg'
       );
 
       assert.equal(
         crushinator.crush(url, {}),
-        'https://tedcdnpi-a.akamaihd.net/r/images.ted.com/image.jpg'
+        'https://pi.tedcdn.com/r/images.ted.com/image.jpg'
       );
     });
 
@@ -150,12 +151,12 @@ describe('crushinator', function () {
 
           assert.equal(
             crushinator.crush('http:' + url, { width: 200 }),
-            'https://tedcdnpi-a.akamaihd.net/r/' + imageHost + '/image.jpg?w=200'
+            'https://pi.tedcdn.com/r/' + imageHost + '/image.jpg?w=200'
           );
 
           assert.equal(
             crushinator.crush('https:' + url, { width: 200 }),
-            'https://tedcdnpi-a.akamaihd.net/r/' + imageHost + '/image.jpg?w=200'
+            'https://pi.tedcdn.com/r/' + imageHost + '/image.jpg?w=200'
           );
         });
       });


### PR DESCRIPTION
Crushinator's canonical host has moved from `tedcdnpi-a.akamaihd.net` to `pi.tedcdn.com`

Code and documentation should be updated to reflect this change.