### PR TITLE
Gracefully handle invalid input values

### DIFF
--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -55,7 +55,7 @@ Returns the portion of input URL that corresponds to the host name.
 @returns {string}
 */
 function extractHost(url) {
-  return url.replace(/.*\/\/([^\/]+).*/, '$1');
+  return String(url).replace(/.*\/\/([^\/]+).*/, '$1');
 }
 
 /**
@@ -75,7 +75,7 @@ Restore a previously crushed URL to its original form.
 @returns {string}
 */
 export function uncrush(url) {
-  const parts = url.match(
+  const parts = String(url).match(
     /(.+)?\/\/(?:(?:img(?:-ssl)?|pi)\.tedcdn\.com|tedcdnpi-a\.akamaihd\.net)\/r\/([^?]+)/
   );
 

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -47,6 +47,11 @@ describe('crushinator', function () {
       assert(!crushinator.crushable('http://test.com/images/test.jpg'));
       assert(!crushinator.crushable('https://test.com/images/test.jpg'));
     });
+
+    it('should uncomplainingly disconfirm incoherent values', function () {
+      assert(!crushinator.crushable(undefined));
+      assert(!crushinator.crushable(Infinity));
+    });
   });
 
   describe('uncrush', function () {
@@ -76,6 +81,11 @@ describe('crushinator', function () {
         'http://test.com/images/test.jpg'
       );
     });
+
+    it('should politely pass on uncrushing incoherent values', function () {
+      assert.equal(crushinator.uncrush(undefined), undefined);
+      assert.equal(crushinator.uncrush(Infinity), Infinity);
+    });
   });
 
   describe('crush', function () {
@@ -92,6 +102,11 @@ describe('crushinator', function () {
 
     afterEach(function () {
       sandbox.restore();
+    });
+
+    it('should politely pass on crushing incoherent values', function () {
+      assert.equal(crushinator.crush(undefined), undefined);
+      assert.equal(crushinator.crush(Infinity), Infinity);
     });
 
     it('should warn about deprecation of the deprecated query string format', function () {


### PR DESCRIPTION
Public API methods currently throw JS errors when invalid image URLs are provided.

With this commit, these methods return the provided value instead.

Specs are included to describe the new behavior.