### PR TITLE
Add Object.assign polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
+  "plugins": ["transform-object-assign"],
   "presets": ["es2015"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### (Upcoming)
 
+* [#13](https://github.com/tedconf/js-crushinator-helpers/pull/13) Add Object.assign polyfill
+
 [(Commit list.)](https://github.com/tedconf/js-crushinator-helpers/compare/50d2beb...master)
 
 ### 2.3.1

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "babel-plugin-transform-object-assign": "^6.8.0",
     "babel-preset-es2015": "^6.5.0",
     "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.5.2",


### PR DESCRIPTION
Babel's [ES2015 preset](http://babeljs.io/docs/plugins/preset-es2015/) does include [polyfills](http://babeljs.io/docs/usage/polyfill/). Consequently, `Object.assign` fails [in environments where it is missing.](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign#Browser_compatibility)

This commit adds [the Object.assign transform](https://babeljs.io/docs/plugins/transform-object-assign/) to correct that issue.