### PR TITLE
Allow the Crushinator host location to be overridden

### DIFF
--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -59,6 +59,13 @@ function extractHost(url) {
 }
 
 /**
+Overridable global configuration options.
+*/
+export const config = {
+  host: 'https://pi.tedcdn.com',
+};
+
+/**
 Check to see if a URL passes Crushinator's host whitelist.
 
 @param {string} url - URL of image to check.
@@ -137,7 +144,7 @@ export function crush(url, options={}) {
     ));
   }
 
-  return 'https://pi.tedcdn.com/r/' +
+  return config.host + '/r/' +
     url.replace(/.*\/\//, '') +
     (options ? '?' + options : '');
 }

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -177,6 +177,23 @@ describe('crushinator', function () {
       });
     });
 
+    // Testing configuration overrides
+    context('with configurations', function () {
+      const defaults = Object.assign({}, crushinator.config);
+
+      afterEach(function () {
+        Object.assign(crushinator.config, defaults);
+      });
+
+      it('should use the crushinator host override', function () {
+        crushinator.config.host = 'https://example.com';
+        assert.equal(
+          crushinator.crush('https://images.ted.com/image.jpg'),
+          'https://example.com/r/images.ted.com/image.jpg'
+        );
+      });
+    });
+
     // Testing the options API
     context('options API', function () {
       it('should recognize the width option', function () {


### PR DESCRIPTION
This simply makes it easier to test new features against a local Crushinator instance. e.g.:

```javascript
crushinator.config.host = 'http://localhost:8124';
crushinator.crush('https://images.ted.com/image.jpg');
  // => http://localhost:8124/r/images.ted.com/image.jpg
```