### PR TITLE
Add default options to the `crush` helper

### DIFF
--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -4,6 +4,7 @@ Library of simple JS methods to produce crushed image URLs.
 http://github.com/tedconf/js-crushinator-helpers
 */
 
+import { defaultify } from './lib/defaultify';
 import { parameterize } from './lib/parameterize';
 import { serialize } from './lib/query-string';
 import { warn } from './lib/log';
@@ -54,6 +55,7 @@ function extractHost(url) {
 Overridable global configuration options.
 */
 export const config = {
+  defaults: true,
   host: 'https://pi.tedcdn.com',
 };
 
@@ -97,9 +99,12 @@ specified options string:
 @param {number} [options.width] - Target image width in pixels.
 @param {number} [options.height] - Target image height in pixels.
 @param {number} [options.quality] - Image quality as a percentage
-    (0-100).
+    (0-100). Defaults to 82.
 @param {boolean} [options.fit] - Will zoom and crop the image
-    for best fit into the target dimensions.
+    for best fit into the target dimensions (width and height)
+    if both are provided. Defaults to true.
+@param {boolean} [options.defaults] - Default options are excluded
+    if set to false. Defaults to true.
 @param {string} [options.align] - If cropping occurs, the image
     can be aligned to the "top", "bottom", "left", "right", or
     "middle" of the crop frame.
@@ -134,9 +139,9 @@ export function crush(url, options = {}) {
     params = options;
   }
 
-  // Stringify object options
+  // Stringify object options while adding defaults
   if (typeof options === 'object') {
-    params = serialize(parameterize(options));
+    params = serialize(parameterize(defaultify(options)));
   }
 
   return `${config.host}/r/${uncrushed.replace(/.*\/\//, '')}${params ? `?${params}` : ''}`;

--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -141,7 +141,10 @@ export function crush(url, options = {}) {
 
   // Stringify object options while adding defaults
   if (typeof options === 'object') {
-    params = serialize(parameterize(defaultify(options)));
+    params = serialize(parameterize(defaultify(Object.assign(
+      { defaults: config.defaults },
+      options,
+    ))));
   }
 
   return `${config.host}/r/${uncrushed.replace(/.*\/\//, '')}${params ? `?${params}` : ''}`;

--- a/src/lib/defaultify.js
+++ b/src/lib/defaultify.js
@@ -1,0 +1,29 @@
+/**
+Add defaults to a Crushinator helper options object,
+unless explicitly requested not to do so.
+*/
+
+import { prepBoolean } from './preppers';
+
+/**
+Default Crushinator helper options.
+*/
+const defaultOptions = {
+  fit: true,
+  unsharp: true,
+  quality: 82,
+};
+
+/**
+Given a list of options returns those options seeded with the defaults
+specified above unless the "defaults" option is set to false.
+
+@returns {object}
+*/
+export function defaultify(options = {}) {
+  return Object.assign({}, (
+    prepBoolean(options.defaults, true) ? defaultOptions : {}
+  ), options);
+}
+
+export default defaultify;

--- a/src/lib/preppers.js
+++ b/src/lib/preppers.js
@@ -20,17 +20,31 @@ export function isBlank(value) {
 }
 
 /**
+Prepare a boolean value.
+
+@param {*} value - Value that should be typecast as a boolean.
+@returns {boolean}
+*/
+export function prepBoolean(value, defaultValue = false) {
+  return (
+    typeof value === 'undefined' ?
+    defaultValue :
+    !!value
+  );
+}
+
+/**
 Prepare a numerical value.
 
 @param {*} value - Value that should be typecast as a number.
 @returns {number}
 */
-export function prepNumber(value, fallback = 0) {
-  let outgoing = isBlank(value) ? fallback : Number(value);
+export function prepNumber(value, defaultValue = 0) {
+  let outgoing = isBlank(value) ? defaultValue : Number(value);
 
   if (!isFinite(outgoing)) {
     error(`"${value}" is not a finite number`);
-    outgoing = fallback;
+    outgoing = defaultValue;
   }
 
   return outgoing;


### PR DESCRIPTION
Talk hero images and thumbnails are the images Crushinator handles most frequently, and we've discovered a set of options that generally produce nicer-looking versions of such images.

It's tedious to remember to use these options every time, so let's set up the `crushinator.crush` helper method with some sensible defaults:

* "Best fit" mode (zoom and crop when a width and height are both specified)
* An unsharp mask which helps preserve image detail during resampling
* Quality at 82% (which may require some more tuning but seems to be the average happy medium between good quality and smaller filesizes)