### PR TITLE
Use top edge for default cropping

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ crushinator.crush('https://images.ted.com/image.jpg', { defaults: false })
 When enabled, the following defaults are included:
 
 * [`fit: true`](#fit)
+* [`align: 'top'`](#align)
 * [`quality: 82`](#quality)
 * [`unsharp: true`](#unsharp)
 
@@ -203,7 +204,9 @@ crushinator.crush('https://images.ted.com/image.jpg', {
 ```
 
 ### align
-String. When cropping an image (including "best fit" cropping) it's sometimes useful to dynamically specify a dynamic start point for where the crop begins in addition to the standard pixel offset. The align option allows you to specify whether you want cropping to start at the `"top"`, `"bottom"`, `"left"`, `"right"`, or `"middle"` of the image.
+String. When cropping an image (including "best fit" cropping) it's sometimes useful to dynamically specify an image edge at which cropping should begin. Cropping may be aligned to the `"top"`, `"bottom"`, `"left"`, `"right"`, or `"middle"` of the image.
+
+The default alignment is `"top"` since this is best suited for cropping TED Talks images.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ crushinator.crush('https://images.ted.com/image.jpg', {
 ### align
 String. When cropping an image (including "best fit" cropping) it's sometimes useful to dynamically specify an image edge at which cropping should begin. Cropping may be aligned to the `"top"`, `"bottom"`, `"left"`, `"right"`, or `"middle"` of the image.
 
-The default alignment is `"top"` since this is best suited for cropping TED Talks images.
-
 Example:
 
 ```
@@ -215,7 +213,7 @@ crushinator.crush('https://images.ted.com/image.jpg', {
   width: 320,
   height: 240,
   fit: true,
-  align: 'top',
+  align: 'middle',
 })
 ```
 

--- a/src/lib/defaultify.js
+++ b/src/lib/defaultify.js
@@ -10,6 +10,7 @@ Default Crushinator helper options.
 */
 const defaultOptions = {
   fit: true,
+  align: 'top',
   unsharp: true,
   quality: 82,
 };

--- a/src/lib/defaultify.js
+++ b/src/lib/defaultify.js
@@ -10,7 +10,6 @@ Default Crushinator helper options.
 */
 const defaultOptions = {
   fit: true,
-  align: 'top',
   unsharp: true,
   quality: 82,
 };

--- a/src/lib/fit-option.js
+++ b/src/lib/fit-option.js
@@ -11,9 +11,11 @@ export function fit(options) {
   if (options.fit && options.width && options.height) {
     Object.assign(params, {
       op: '^',
-      gravity: 't',
       c: `${prepNumber(options.width)},${prepNumber(options.height)}`,
     });
+
+    // A custom alignment may be specified with the fit option
+    if (!options.align) params.gravity = 't';
   }
 
   return params;

--- a/src/lib/fit-option.js
+++ b/src/lib/fit-option.js
@@ -11,7 +11,7 @@ export function fit(options) {
   if (options.fit && options.width && options.height) {
     Object.assign(params, {
       op: '^',
-      gravity: 'c',
+      gravity: 't',
       c: `${prepNumber(options.width)},${prepNumber(options.height)}`,
     });
   }

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -305,7 +305,7 @@ describe('crushinator', () => {
             height: 240,
             fit: true,
           }),
-          `${crushed}?w=320&h=240&op=%5E&gravity=t&c=320%2C240`,
+          `${crushed}?w=320&h=240&op=%5E&c=320%2C240&gravity=t`,
         );
       });
 
@@ -333,6 +333,18 @@ describe('crushinator', () => {
         assert.equal(
           crushinator.crush(uncrushed, { align: 'middle' }),
           `${crushed}?gravity=c`,
+        );
+      });
+
+      it('should allow custom alignment to override the gravity selected by the fit option', () => {
+        assert.equal(
+          crushinator.crush(uncrushed, {
+            width: 320,
+            height: 240,
+            align: 'middle',
+            fit: true,
+          }),
+          `${crushed}?w=320&h=240&gravity=c&op=%5E&c=320%2C240`,
         );
       });
 

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -176,7 +176,7 @@ describe('crushinator', () => {
 
     // Testing default options
     context('with defaults', () => {
-      const defaultParams = 'u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=82';
+      const defaultParams = 'gravity=n&u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=82';
 
       context('disabled via config', () => {
         beforeEach(() => {
@@ -226,7 +226,7 @@ describe('crushinator', () => {
         it('should use the default options', () => {
           assert.equal(
             crushinator.crush(uncrushed, { quality: 99 }),
-            `${crushed}?u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=99`,
+            `${crushed}?gravity=n&u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=99`,
           );
         });
       });

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -176,7 +176,7 @@ describe('crushinator', () => {
 
     // Testing default options
     context('with defaults', () => {
-      const defaultParams = 'gravity=n&u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=82';
+      const defaultParams = 'u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=82';
 
       context('disabled via config', () => {
         beforeEach(() => {
@@ -226,7 +226,7 @@ describe('crushinator', () => {
         it('should use the default options', () => {
           assert.equal(
             crushinator.crush(uncrushed, { quality: 99 }),
-            `${crushed}?gravity=n&u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=99`,
+            `${crushed}?u%5Br%5D=2&u%5Bs%5D=0.5&u%5Ba%5D=0.8&u%5Bt%5D=0.03&quality=99`,
           );
         });
       });
@@ -305,7 +305,7 @@ describe('crushinator', () => {
             height: 240,
             fit: true,
           }),
-          `${crushed}?w=320&h=240&op=%5E&gravity=c&c=320%2C240`,
+          `${crushed}?w=320&h=240&op=%5E&gravity=t&c=320%2C240`,
         );
       });
 


### PR DESCRIPTION
Talk images can look awkward when center-cropped (for best fit mode).

Top alignment looks nicer.