### PR TITLE
Percent-encode quotes and parens in image URLs

### DIFF
--- a/src/crushinator.js
+++ b/src/crushinator.js
@@ -7,6 +7,7 @@ http://github.com/tedconf/js-crushinator-helpers
 import { defaultify } from './lib/defaultify';
 import { parameterize } from './lib/parameterize';
 import { serialize } from './lib/query-string';
+import { desnag } from './lib/desnag';
 import { warn } from './lib/log';
 
 /**
@@ -185,7 +186,7 @@ export function crush(url, options = {}) {
     ))));
   }
 
-  return `${config.host}/r/${uncrushed.replace(/.*\/\//, '')}${params ? `?${params}` : ''}`;
+  return desnag(`${config.host}/r/${uncrushed.replace(/.*\/\//, '')}${params ? `?${params}` : ''}`);
 }
 
 export default crush;

--- a/src/lib/desnag.js
+++ b/src/lib/desnag.js
@@ -1,0 +1,13 @@
+/**
+Given a URL string, returns a version where parentheses and quotation
+marks (single and double) are percent-encoded.
+
+Though these characters are legal in URLs, they can cause problems
+in some interpolations. Percent encoding them avoids that pitfall.
+*/
+
+const percentifyChar = c => `%${c.charCodeAt(0).toString(16)}`;
+
+export const desnag = url => url.replace(/[()'"]/g, percentifyChar);
+
+export default desnag;

--- a/test/crushinator.spec.js
+++ b/test/crushinator.spec.js
@@ -117,6 +117,11 @@ describe('crushinator', () => {
       expect(crushinator.crush(url, {})).toEqual('https://pi.tedcdn.com/r/images.ted.com/image.jpg');
     });
 
+    test('should percent-encode known problematic characters', () => {
+      const url = 'https://images.ted.com/Joe\'s "air quotes" (1).jpg';
+      expect(crushinator.crush(url)).toEqual('https://pi.tedcdn.com/r/images.ted.com/Joe%27s %22air quotes%22 %281%29.jpg');
+    });
+
     // Host tests
     describe('Host testing', () => {
       imageHosts.forEach((imageHost) => {


### PR DESCRIPTION
Simple change to percent-encode any quotes or parentheses in the `crush` method's image URL output.

This helps avoid the common front-end pitfall of forgetting to escape these characters when interpolating image URLs as part of a CSS string.